### PR TITLE
Fix exportJSON function

### DIFF
--- a/gui.js
+++ b/gui.js
@@ -757,7 +757,20 @@ var CGUI = function()
 
     // Generate JS song data
     var dataURI = "data:text/javascript;base64," + btoa(songToJSON(mSong, true));
-    window.open(dataURI);
+    var link = document.createElement('a');
+    link.setAttribute('download', 'sonant-x-export.json');
+    link.setAttribute('href', dataURI);
+    document.body.appendChild(link);
+    link.click();
+    setTimeout(
+      function()
+      {
+        // Wait 1000ms before removing the link
+        // This gives IE11 enough time to process the download (it will fail if the link is removed)
+        document.body.removeChild(link);
+      },
+      1000
+    );
     return false;
   };
 


### PR DESCRIPTION
On Chrome 75, OS X, the `exportJSON` function fails to work. This commit switches the approach to clicking an `a` tag, which has the data URI as the `href`.